### PR TITLE
db.t2 instances are depreciated for MySQL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "aws_db_subnet_group" "private" {
 resource "aws_db_instance" "database" {
   allocated_storage = 5
   engine            = "mysql"
-  instance_class    = "db.t2.micro"
+  instance_class    = "db.t3.micro"
   username          = "admin"
   password          = "notasecurepassword"
 


### PR DESCRIPTION
db.t2 instances are depreciated for MySQL. The run will fail with the folllowing error:

```
aws_db_instance.database: Creating...
╷
│ Error: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=mysql, EngineVersion=8.0.35, LicenseModel=general-public-license. For supported combinations of instance class and database engine version, see the documentation.
│       status code: 400, request id: 34690921-0d2c-4514-ae64-3075a3f31e60
│ 
│   with aws_db_instance.database,
│   on main.tf line 100, in resource "aws_db_instance" "database":
│  100: resource "aws_db_instance" "database" {
│ 
╵
Operation failed: failed running terraform apply (exit 1)
```

Suggesting `db.t3.micro` instead